### PR TITLE
Include version number in info command

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -17,6 +17,8 @@ jobs:
         uses: matootie/github-docker@v2.2.3
         with:
           accessToken: ${{ secrets.GITHUB_TOKEN }}
+          buildArg: |
+            VERSION=${GITHUB_REF##*/}
 
       - name: Save DigitalOcean Kubernetes Config
         uses: matootie/dokube@v1.3.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.7-slim
 WORKDIR /app
 COPY . /app
+ARG VERSION
 RUN apt-get update && apt-get install -y libenchant1c2a
 RUN pip install --upgrade pip && \
     pip install pipenv && \
     pipenv install
-CMD ["pipenv", "run", "python", "runner.py", "run"]
+CMD ["pipenv", "run", "python", "runner.py", "run", "--version", "$VERSION"]

--- a/kiki/__init__.py
+++ b/kiki/__init__.py
@@ -23,6 +23,8 @@ class Kiki(commands.Bot):
 
         self._redis_url = kwargs.get("redis_url")
         self.redis = None
+        
+        self.version = kwargs.get("version")
 
         super().__init__(command_prefix=command_prefix, **kwargs)
 

--- a/kiki/plugins/info/cogs.py
+++ b/kiki/plugins/info/cogs.py
@@ -32,16 +32,20 @@ class Info(commands.Cog):
 
         embed.set_author(
             name="Kikiriki Studios Canada",
-            url="https://kikiriki.ca/",
+            url="https://github.com/matootie/kiki",
             icon_url="https://cdn.discordapp.com/attachments/604373743837511693/653741067904221231/icon_circle_variant_1000x1000.png")  # noqa
 
         embed.set_footer(text="Report any issues to an admin.")
 
         db_status = bool(self.bot.redis)
-
         embed.add_field(
             name="Database connection",
             value="🟢 Running" if db_status else "🔴 Down",
+            inline=False)
+
+        embed.add_field(
+            name="Version",
+            value=self.bot.version,
             inline=False)
 
         await ctx.send(embed=embed)

--- a/kiki/plugins/levels/cogs.py
+++ b/kiki/plugins/levels/cogs.py
@@ -85,7 +85,8 @@ class Levels(commands.Cog):
 
         word_lengths = [
             len(word) for word in m.split(" ") if self._d.check(word)]
-        avg_word_length = sum(word_lengths) / len(word_lengths)
+        divisor = len(word_lengths) if len(word_lengths) > 0 else 1
+        avg_word_length = sum(word_lengths) / divisor
         multiplier = math.pow(avg_word_length - 4.7, 3)/120 + 1
 
         return int(points * multiplier)

--- a/kiki/utils/cli.py
+++ b/kiki/utils/cli.py
@@ -18,7 +18,8 @@ def cli():
 
 
 @cli.command()
-def run():
+@click.option("-V", "--version", "version")
+def run(version: str = "v0.1.0-alpha"):
     """
     Run the bot.
     """
@@ -30,5 +31,5 @@ def run():
 
     redis_url = os.environ.get("REDIS_URL")
 
-    kiki = Kiki(redis_url=redis_url)
+    kiki = Kiki(redis_url=redis_url, version=version)
     kiki.run(token)


### PR DESCRIPTION
### Issue Endorsed by Maintainer

Closes #27.

### Description of the Change

Simply takes the version number from the `GITHUB_REF` in the autorelease workflow, injects it into Kiki bot as a command-line argument. The rest is trivial.

### Alternate Designs

N/A

### Possible Drawbacks

N/A

### Verification Process

Ran locally with mock environment.

### Release Notes

Kiki will now tell you what the running version is.
